### PR TITLE
Use <spring-data-releasetrain.version>

### DIFF
--- a/03-boot2/pom.xml
+++ b/03-boot2/pom.xml
@@ -23,6 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <junit-jupiter.version>5.2.0</junit-jupiter.version>
+        <spring-data-releasetrain.version>Lovelace-M3</spring-data-releasetrain.version>
     </properties>
 
     <dependencies>
@@ -43,7 +44,6 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jdbc</artifactId>
-            <version>1.0.0.M3</version>
         </dependency>
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>

--- a/04-boot2-answer/pom.xml
+++ b/04-boot2-answer/pom.xml
@@ -23,6 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <junit-jupiter.version>5.2.0</junit-jupiter.version>
+        <spring-data-releasetrain.version>Lovelace-M3</spring-data-releasetrain.version>
     </properties>
 
     <dependencies>
@@ -42,12 +43,6 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jdbc</artifactId>
-            <version>1.0.0.M3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-commons</artifactId>
-            <version>2.1.0.M3</version>
         </dependency>
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>


### PR DESCRIPTION
spring-data-commonsのversionも上書きできるので、BootでSpring Data JDBCを使う場合は`<spring-data-releasetrain.version>`を使った方が良いかと。